### PR TITLE
Fix empty required array in JSON Schema

### DIFF
--- a/lib/cov_loupe/base_tool.rb
+++ b/lib/cov_loupe/base_tool.rb
@@ -72,12 +72,13 @@ module CovLoupe
     }.freeze
 
     def self.coverage_schema(additional_properties: {}, required: [])
-      {
+      schema = {
         type: 'object',
         additionalProperties: false,
-        properties: COMMON_PROPERTIES.merge(additional_properties),
-        required: required
-      }.freeze
+        properties: COMMON_PROPERTIES.merge(additional_properties)
+      }
+      schema[:required] = required unless required.empty?
+      schema.freeze
     end
 
     FILE_INPUT_SCHEMA = coverage_schema(


### PR DESCRIPTION
## Summary

Fixes an incompatibility with the `mcp` gem (0.6.0) where JSON Schema validation fails when tools have no required fields.

**Problem:**
JSON Schema draft-04 requires the `required` array to have at least 1 item if present. When `coverage_schema` is called without explicit required fields, it was including `required: []` which causes:

```
Invalid JSON Schema: The property '#/required' did not contain a minimum number of items 1
```

**Solution:**
Only include the `required` key when there are actually required fields specified.

## Test plan

- [x] All 1334 existing tests pass
- [x] Verified MCP server starts successfully after fix
- [x] Tested with Claude Code MCP integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)