### PR TITLE
Allow MCP Ruby SDK 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Full documentation is available at **[https://keithrbennett.github.io/cov-loupe/
 ## Requirements
 
 - **Ruby >= 3.2** (required by `mcp` gem dependency)
-- `mcp` gem >= 0.15 and < 1.0
+- `mcp` gem >= 0.15 and < 2.0
 - SimpleCov-generated `.resultset.json` file
 - `simplecov` gem >= 0.21
 

--- a/cov-loupe.gemspec
+++ b/cov-loupe.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # MCP 0.15 is the minimum supported version because earlier releases reported tool
   # argument-validation failures as top-level JSON-RPC errors. Since 0.15, those failures are
   # tools/call results with isError: true, which is cov-loupe's documented response contract.
-  spec.add_dependency 'mcp', '>= 0.15', '< 1.0'
+  spec.add_dependency 'mcp', '>= 0.15', '< 2.0'
   spec.add_dependency 'simplecov', '>= 0.21', '< 2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 

--- a/spec/cov_loupe/version_spec.rb
+++ b/spec/cov_loupe/version_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'CovLoupe::VERSION' do
   describe 'runtime dependency constraints' do
     # MCP 0.15 changed argument-validation failures from JSON-RPC errors to
     # tools/call results with isError: true.
-    it 'sets MCP 0.15 as the minimum supported version' do
+    it 'supports MCP 0.15 through 1.x' do
       gemspec = Gem::Specification.load(gemspec_file)
       mcp_dependency = gemspec.runtime_dependencies.find { |dependency| dependency.name == 'mcp' }
       expect(mcp_dependency).not_to be_nil, 'expected the gemspec to declare an mcp runtime dependency'
@@ -85,7 +85,8 @@ RSpec.describe 'CovLoupe::VERSION' do
       requirement = mcp_dependency.requirement
       expect(requirement).to be_satisfied_by(Gem::Version.new('0.15.0'))
       expect(requirement).not_to be_satisfied_by(Gem::Version.new('0.14.0'))
-      expect(requirement).not_to be_satisfied_by(Gem::Version.new('1.0.0'))
+      expect(requirement).to be_satisfied_by(Gem::Version.new('1.0.0'))
+      expect(requirement).not_to be_satisfied_by(Gem::Version.new('2.0.0'))
     end
   end
 


### PR DESCRIPTION
## Summary

- widen the runtime `mcp` requirement from `< 1.0` to `< 2.0`
- document the newly supported MCP 1.x range
- update the dependency contract spec to accept 1.x while continuing to reject versions below 0.15 and at or above 2.0

Closes #21.

## Validation

- `bundle exec rspec` with MCP 1.0.0 resolved: 1,446 examples, 0 failures
- `bundle exec rubocop --cache false`: 190 files inspected, no offenses
- downstream Heatwave MCP integration tests with this local gem and MCP 1.0.0: 85 runs, 276 assertions, 0 failures, 0 errors

The repository ignores `Gemfile.lock`, so no lockfile change is included.
